### PR TITLE
Fix #1 - Typo in example config file

### DIFF
--- a/conf/servers.json.example
+++ b/conf/servers.json.example
@@ -1,5 +1,5 @@
 {
-  Server A": {
+  "Server A": {
     "url": "http://one.example.com:2812",
     "user": "monit",
     "passwd": "secret"


### PR DESCRIPTION
There was a typo (missing double quotes). This fixes #1