### PR TITLE
Sort the service items based on the errors

### DIFF
--- a/bin/monit-dashboard.py
+++ b/bin/monit-dashboard.py
@@ -7,6 +7,8 @@ import json
 import os
 import sys
 import datetime
+from collections import OrderedDict
+from operator import itemgetter
 
 urls = ('/', 'index',
         '/help', 'help'
@@ -27,7 +29,7 @@ output = []
 def getMonit():
     output = []
     server = {}
-    checks = {}
+    checks = OrderedDict()
     xmlQuery = "/_status?format=xml"
 
     with open('{0}/conf/servers.json'.format(os.path.expanduser('.'))) as f:
@@ -42,14 +44,16 @@ def getMonit():
 
             services = allstat['service']
             status = {}
-            checks = {}
+            checks = OrderedDict()
 
             for service in services:
                 name = service['name']
                 status[name] = int(service['status'])
                 checks[service['name']] = status[name]
 
-                server = dict(name=site, url=s['url'], result=checks)
+            sorted_checks = OrderedDict()
+            sorted_checks = OrderedDict(sorted(checks.iteritems(), key=itemgetter(1), reverse=True))
+            server = dict(name=site, url=s['url'], result=sorted_checks)
 
             output.append(server)
 

--- a/bin/monit-dashboard.py
+++ b/bin/monit-dashboard.py
@@ -28,8 +28,6 @@ output = []
 
 def getMonit():
     output = []
-    server = {}
-    checks = OrderedDict()
     xmlQuery = "/_status?format=xml"
 
     with open('{0}/conf/servers.json'.format(os.path.expanduser('.'))) as f:
@@ -44,12 +42,13 @@ def getMonit():
 
             services = allstat['service']
             status = {}
+            server = {}
             checks = OrderedDict()
 
             for service in services:
                 name = service['name']
                 status[name] = int(service['status'])
-                checks[service['name']] = status[name]
+                checks[name] = status[name]
 
             sorted_checks = OrderedDict()
             sorted_checks = OrderedDict(sorted(checks.iteritems(), key=itemgetter(1), reverse=True))


### PR DESCRIPTION
@adriaaah 

Services list in the dashboard doesn't have any order, its fine since monit API also not providing the services list based on any particular order.

But it would be great if it shows the `failed services` on top, because we need to scroll down the entire page to find the failed services since it's not showing in any particular order.

I added the feature to sort the services list based on error/status code, so it will show the failed services on top.